### PR TITLE
pass full input params to getSource so `type` is not missing from object

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -410,7 +410,7 @@ class Engine {
 
             // download input to <baseDirectory>/<stepNumber>-<transformerName>/inputfile and set input.path
             transformerInput = await getSource(
-                input.url,
+                input,
                 transformerDirectory.base,
                 false
             );


### PR DESCRIPTION
## Description

this test was failing because of this bug: https://git.corp.adobe.com/nui/transformer-image/blob/master/test/engine.test.js#L164

Fixes # none

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
