### PR TITLE
NUI-1582 fix dependent_module_tests

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -166,9 +166,9 @@ class Prepare{
                         dereference: true,
                         // ensure files can be read by host system by running chmod before copy
                         filter: src => {
-                            // if (directory.postprocessing && src.startsWith(directory.postprocessing)) {
-                            //     return false;
-                            // }
+                            if (directory.postprocessing && src.startsWith(directory.postprocessing)) {
+                                return false;
+                            }
                             fse.chmodSync(src, 0o766);
                             debug(`WORKER_TEST_MODE: copying ${src} to /out`);
                             return true;

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -160,8 +160,15 @@ class Prepare{
             }
 
             for (const directory of directories) {
-                if(process.env.WORKER_TEST_MODE){
-                    await fse.copy(directory.out, "/out", copyOptions);
+                if (process.env.WORKER_TEST_MODE) {
+                    const newCopyOptions = copyOptions;
+                    newCopyOptions.filter = src => {
+                        if (src.startsWith(directory.postprocessing)) {
+                            return false;
+                        }
+                        copyOptions.filter(src)
+                    };
+                    await fse.copy(directory.out, "/out", newCopyOptions);
                 }
                 if (directory && directory.base) {
                     // should also remove metadata (error and mimetype) files, if not already cleaned

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -161,14 +161,19 @@ class Prepare{
 
             for (const directory of directories) {
                 if (process.env.WORKER_TEST_MODE) {
-                    const newCopyOptions = copyOptions;
-                    newCopyOptions.filter = src => {
-                        if (src.startsWith(directory.postprocessing)) {
-                            return false;
+                    await fse.copy(directory.out, "/out", {
+                        // Make sure symlinks are copied as binaries and not symlinks
+                        dereference: true,
+                        // ensure files can be read by host system by running chmod before copy
+                        filter: src => {
+                            // if (directory.postprocessing && src.startsWith(directory.postprocessing)) {
+                            //     return false;
+                            // }
+                            fse.chmodSync(src, 0o766);
+                            debug(`WORKER_TEST_MODE: copying ${src} to /out`);
+                            return true;
                         }
-                        copyOptions.filter(src);
-                    };
-                    await fse.copy(directory.out, "/out", newCopyOptions);
+                    });
                 }
                 if (directory && directory.base) {
                     // should also remove metadata (error and mimetype) files, if not already cleaned

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -166,7 +166,7 @@ class Prepare{
                         if (src.startsWith(directory.postprocessing)) {
                             return false;
                         }
-                        copyOptions.filter(src)
+                        copyOptions.filter(src);
                     };
                     await fse.copy(directory.out, "/out", newCopyOptions);
                 }


### PR DESCRIPTION
## Description
This fixes the error in `dependent_module_testa` in `asset-compute-sdk` after merging NUI-1582:
```
error: EACCES: permission denied, unlink '/home/circleci/appLatest/worker-cameraraw/action/.nui/2021_11_04T01_33_35_576Z/out/post/rendition0.gif'
```
Error build https://circle.ci.adobeitc.com/gh/nui/ci-opensource/22266
Fixed build https://circle.ci.adobeitc.com/gh/nui/ci-opensource/22277 (Ignore security risk error since I am using a branch)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
