### PR TITLE
source mimetype could be in source.mimetype

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -27,7 +27,8 @@ class Asset {
     }
 
     get type() {
-        return this.params ? this.params.type : undefined;
+        // to stay backwards compatible, map `mimeType` or `mimetype` to `type`
+        return this.params ? (this.params.type || this.params.mimeType || this.params.mimetype) : undefined;
     }
 
     get url() {

--- a/lib/storage/http.js
+++ b/lib/storage/http.js
@@ -20,13 +20,14 @@ const MAX_RETRY_DURATION_UPLOAD = 900000; // 15 mins
 
 async function download(asset, file) {
     try {
+        const mimetype = asset.type || asset.mimetype || asset.mimeType;
         console.log(`downloading asset ${AssetComputeLogUtils.redactUrl(asset.url)} into ${file}\nheaders:`, asset.headers);
-        console.log(`asset content type: ${asset.type}, size: ${asset.size}`);
+        console.log(`asset content type: ${mimetype}, size: ${asset.size}`);
 
         await http.downloadFileConcurrently(asset.url, file, {
             retryEnabled: !process.env.ASSET_COMPUTE_DISABLE_RETRIES,
             headers: asset.headers,
-            contentType: asset.type || asset.mimetype || asset.mimeType,
+            contentType: mimetype,
             fileSize: asset.size
         });
         console.log('download finished successfully');

--- a/lib/storage/http.js
+++ b/lib/storage/http.js
@@ -26,7 +26,7 @@ async function download(asset, file) {
         await http.downloadFileConcurrently(asset.url, file, {
             retryEnabled: !process.env.ASSET_COMPUTE_DISABLE_RETRIES,
             headers: asset.headers,
-            contentType: asset.type || asset.mimeType,
+            contentType: asset.type || asset.mimetype || asset.mimeType,
             fileSize: asset.size
         });
         console.log('download finished successfully');

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -115,16 +115,17 @@ class Storage {
     // upon the file extension so it is best to try to use the appropriate one
     // based on the filename, url, or mimetype
     static getSourceFilename(source) {
+        const mimetype = source.type || source.mimetype || source.mimeType;
         if (source.name) {
-            return `${SOURCE_BASENAME}${Storage.getExtension(source.name, source.mimeType)}`;
+            return `${SOURCE_BASENAME}${Storage.getExtension(source.name, mimetype)}`;
         }
     
         if (source.url && validUrl.isUri(source.url)) {
             const basename = path.basename(new URL(source.url).pathname);
-            return  `${SOURCE_BASENAME}${Storage.getExtension(basename, source.mimeType)}`;
+            return  `${SOURCE_BASENAME}${Storage.getExtension(basename, mimetype)}`;
         }
     
-        return `${SOURCE_BASENAME}${Storage.getExtension(null, source.mimeType)}`;
+        return `${SOURCE_BASENAME}${Storage.getExtension(null, mimetype)}`;
     }
     
     static async getSource(paramsSource, inDirectory, disableSourceDownload) {

--- a/test/asset.test.js
+++ b/test/asset.test.js
@@ -45,6 +45,7 @@ describe("asset.js", () => {
         assert.ok(asset.name, 'file');
         assert.ok(asset.extension, '');
     });
+
     it('verifies constructor works properly without params', function () {
         const asset = new Asset();
         assert.ok(asset instanceof Asset);
@@ -56,6 +57,7 @@ describe("asset.js", () => {
         assert.strictEqual(asset.headers, undefined);
         assert.strictEqual(asset.type, undefined);
     });
+
     it('verifies constructor works properly with all the asset params', function () {
         const assetParams = {
             type: 'image/jpeg',
@@ -75,6 +77,7 @@ describe("asset.js", () => {
         assert.strictEqual(asset.headers, assetParams.headers);
         assert.strictEqual(asset.type, assetParams.type);
     });
+
     it('verifies mimetype is mapped to type', function () {
         const assetParams = {
             mimetype: 'image/jpeg'
@@ -86,6 +89,7 @@ describe("asset.js", () => {
         assert.strictEqual(asset.extension, 'jpeg');
         assert.strictEqual(asset.type, assetParams.mimetype);
     });
+
     it('verifies mimeType is mapped to type (mimeType variable name is case sensitive)', function () {
         const assetParams = {
             mimeType: 'image/jpeg'

--- a/test/asset.test.js
+++ b/test/asset.test.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint mocha/no-mocha-arrows: "off" */
+
+'use strict';
+
+const assert = require('assert');
+
+const Asset = require('../lib/asset');
+
+describe("asset.js", () => {
+    it('verifies constructor works properly', function () {
+        let asset = new Asset({}, '', 'file.png');
+        assert.ok(asset instanceof Asset);
+        assert.ok(asset.path, "./file.png");
+        assert.ok(asset.name, 'file.png');
+        assert.ok(asset.extension, 'png');
+        assert.strictEqual(asset.url, undefined);
+        assert.strictEqual(asset.size, undefined);
+        assert.strictEqual(asset.headers, undefined);
+        assert.strictEqual(asset.type, undefined);
+
+        // custom directory
+        asset = new Asset({}, '/path', 'file.png');
+        assert.ok(asset instanceof Asset);
+        assert.ok(asset.path, "/path/file.png");
+        assert.ok(asset.name, 'file.png');
+        assert.ok(asset.extension, 'png');
+        
+        // no extension
+        asset = new Asset({}, '/path', 'file');
+        assert.ok(asset instanceof Asset);
+        assert.ok(asset.path, "/path/file");
+        assert.ok(asset.name, 'file');
+        assert.ok(asset.extension, '');
+    });
+    it('verifies constructor works properly without params', function () {
+        const asset = new Asset();
+        assert.ok(asset instanceof Asset);
+        assert.strictEqual(asset.path, '.');
+        assert.strictEqual(asset.name, '');
+        assert.strictEqual(asset.extension, '');
+        assert.strictEqual(asset.url, undefined);
+        assert.strictEqual(asset.size, undefined);
+        assert.strictEqual(asset.headers, undefined);
+        assert.strictEqual(asset.type, undefined);
+    });
+    it('verifies constructor works properly with all the asset params', function () {
+        const assetParams = {
+            type: 'image/jpeg',
+            url: 'https://adobe.com',
+            headers: {
+                'content-type': 'image/png'
+            },
+            size: 123456
+        };
+        const asset = new Asset(assetParams, '', 'file.jpeg');
+        assert.ok(asset instanceof Asset);
+        assert.strictEqual(asset.path, 'file.jpeg');
+        assert.strictEqual(asset.name, 'file.jpeg');
+        assert.strictEqual(asset.extension, 'jpeg');
+        assert.strictEqual(asset.url, assetParams.url);
+        assert.strictEqual(asset.size, assetParams.size);
+        assert.strictEqual(asset.headers, assetParams.headers);
+        assert.strictEqual(asset.type, assetParams.type);
+    });
+    it('verifies mimetype is mapped to type', function () {
+        const assetParams = {
+            mimetype: 'image/jpeg'
+        };
+        const asset = new Asset(assetParams, '', 'file.jpeg');
+        assert.ok(asset instanceof Asset);
+        assert.strictEqual(asset.path, 'file.jpeg');
+        assert.strictEqual(asset.name, 'file.jpeg');
+        assert.strictEqual(asset.extension, 'jpeg');
+        assert.strictEqual(asset.type, assetParams.mimetype);
+    });
+    it('verifies mimeType is mapped to type', function () {
+        const assetParams = {
+            mimeType: 'image/jpeg'
+        };
+        const asset = new Asset(assetParams, '', 'file.jpeg');
+        assert.ok(asset instanceof Asset);
+        assert.strictEqual(asset.path, 'file.jpeg');
+        assert.strictEqual(asset.name, 'file.jpeg');
+        assert.strictEqual(asset.extension, 'jpeg');
+        assert.strictEqual(asset.type, assetParams.mimeType);
+    });
+
+});

--- a/test/asset.test.js
+++ b/test/asset.test.js
@@ -86,7 +86,7 @@ describe("asset.js", () => {
         assert.strictEqual(asset.extension, 'jpeg');
         assert.strictEqual(asset.type, assetParams.mimetype);
     });
-    it('verifies mimeType is mapped to type', function () {
+    it('verifies mimeType is mapped to type (mimeType variable name is case sensitive)', function () {
         const assetParams = {
             mimeType: 'image/jpeg'
         };

--- a/test/storage/http.test.js
+++ b/test/storage/http.test.js
@@ -90,7 +90,7 @@ describe('http.js', () => {
             assert.ok(fs.existsSync(file));
             assert.ok(nock.isDone());
         });
-        it("should download jpg file (skip head request, source.mimeType)", async () => {
+        it("should download jpg file (skip head request, source.mimeType is a valid mimetype)", async () => {
             // source.mimetype
             const source = new Asset({
                 url: "https://example.com/fakeEarth.jpg",

--- a/test/storage/http.test.js
+++ b/test/storage/http.test.js
@@ -42,7 +42,7 @@ describe('http.js', () => {
 
     describe('download', () => {
 
-        it("should download jpg file (skip head request, source.type)", async () => {
+        it("should download jpg file (skip head request, source.type is a valid mimetype)", async () => {
             // source.type
             const source = {
                 url: "https://example.com/fakeEarth.jpg",

--- a/test/storage/http.test.js
+++ b/test/storage/http.test.js
@@ -114,7 +114,7 @@ describe('http.js', () => {
             assert.ok(fs.existsSync(file));
             assert.ok(nock.isDone());
         });
-        it("should download jpg file (with head request)", async () => { // this test is skipped in case internet is down
+        it("should download jpg file (with head request)", async () => {
             const source = {
                 url: "https://example.com/fakeEarth.jpg",
                 name: "fakeEarth.jpg"

--- a/test/storage/http.test.js
+++ b/test/storage/http.test.js
@@ -19,6 +19,7 @@ const assert = require('assert');
 const mockFs = require("mock-fs");
 const fs = require('fs-extra');
 const { download, upload } = require('../../lib/storage/http');
+const Asset = require('../../lib/asset');
 const nock = require('nock');
 
 const http = require('@adobe/httptransfer');
@@ -41,7 +42,8 @@ describe('http.js', () => {
 
     describe('download', () => {
 
-        it("should download jpg file (skip head request)", async () => { // this test is skipped in case internet is down
+        it("should download jpg file (skip head request, source.type)", async () => {
+            // source.type
             const source = {
                 url: "https://example.com/fakeEarth.jpg",
                 name: "fakeEarth.jpg",
@@ -64,7 +66,55 @@ describe('http.js', () => {
             assert.ok(fs.existsSync(file));
             assert.ok(nock.isDone());
         });
-        it("should download jpg file", async () => { // this test is skipped in case internet is down
+        it("should download jpg file (skip head request, source.mimetype)", async () => {
+            // source.mimetype
+            const source = new Asset({
+                url: "https://example.com/fakeEarth.jpg",
+                name: "fakeEarth.jpg",
+                size: 11,
+                mimetype: 'image/jpeg'
+            });
+
+            mockFs({ './storeFiles/jpg': {} });
+
+            nock("https://example.com")
+                .get("/fakeEarth.jpg")
+                .reply(200, "hello world", {
+                    'content-type': 'image/jpeg',
+                    'content-length': 11
+                });
+
+            const file = './storeFiles/jpg/fakeEarth.jpg';
+
+            await download( source, file);
+            assert.ok(fs.existsSync(file));
+            assert.ok(nock.isDone());
+        });
+        it("should download jpg file (skip head request, source.mimeType)", async () => {
+            // source.mimetype
+            const source = new Asset({
+                url: "https://example.com/fakeEarth.jpg",
+                name: "fakeEarth.jpg",
+                size: 11,
+                mimeType: 'image/jpeg'
+            });
+
+            mockFs({ './storeFiles/jpg': {} });
+
+            nock("https://example.com")
+                .get("/fakeEarth.jpg")
+                .reply(200, "hello world", {
+                    'content-type': 'image/jpeg',
+                    'content-length': 11
+                });
+
+            const file = './storeFiles/jpg/fakeEarth.jpg';
+
+            await download( source, file);
+            assert.ok(fs.existsSync(file));
+            assert.ok(nock.isDone());
+        });
+        it("should download jpg file (with head request)", async () => { // this test is skipped in case internet is down
             const source = {
                 url: "https://example.com/fakeEarth.jpg",
                 name: "fakeEarth.jpg"

--- a/test/storage/http.test.js
+++ b/test/storage/http.test.js
@@ -66,7 +66,7 @@ describe('http.js', () => {
             assert.ok(fs.existsSync(file));
             assert.ok(nock.isDone());
         });
-        it("should download jpg file (skip head request, source.mimetype)", async () => {
+        it("should download jpg file (skip head request, source.mimetype is a valid mimetype)", async () => {
             // source.mimetype
             const source = new Asset({
                 url: "https://example.com/fakeEarth.jpg",

--- a/test/storage/storage.test.js
+++ b/test/storage/storage.test.js
@@ -462,7 +462,56 @@ describe('storage.js', () => {
             assert.ok(nock.isDone());
         });
 
-        it('paramsSource object will use url over mimeType to determine extension', async () => {
+        it('paramsSource object will use url over mime type (as `type`) to determine extension', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.png',
+                type: 'image/jpeg',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.png')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/png',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.png');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.png');
+            assert.ok(nock.isDone());
+        });
+        it('paramsSource object will use url over mime type (as `mimetype`) to determine extension', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.png',
+                mimetype: 'image/jpeg',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.png')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/png',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.png');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.png');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will use url over mime type (as `mimeType` case sensitive) to determine extension', async () => {
             const paramsSource = {
                 url: 'https://example.com/photo/elephant.png',
                 mimeType: 'image/jpeg',
@@ -487,7 +536,59 @@ describe('storage.js', () => {
             assert.ok(nock.isDone());
         });
 
-        it('paramsSource object will use mimeType over url to determine extension if source name is defined', async () => {
+        it('paramsSource object will use mime type (as `type`) over url to determine extension if source name is defined', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.png',
+                type: 'image/jpeg',
+                name: 'file',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.png')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/png',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.jpeg');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.jpeg');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will use mime type (as `mimetype`) over url to determine extension if source name is defined', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.png',
+                mimetype: 'image/jpeg',
+                name: 'file',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.png')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/png',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.jpeg');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.jpeg');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will use mime type (as `mimeType` case sensitive) over url to determine extension if source name is defined', async () => {
             const paramsSource = {
                 url: 'https://example.com/photo/elephant.png',
                 mimeType: 'image/jpeg',
@@ -513,7 +614,33 @@ describe('storage.js', () => {
             assert.ok(nock.isDone());
         });
 
-        it('paramsSource object will not fail if invalid mimetype', async () => {
+        it('paramsSource object will not fail if invalid mimetype (as `mimetype`)', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.jpeg',
+                mimetype: 'not a valid mimetype',
+                name: 'file',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.jpeg')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/png',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will not fail if invalid mimetype (as `mimeType` case sensitive)', async () => {
             const paramsSource = {
                 url: 'https://example.com/photo/elephant.jpeg',
                 mimeType: 'not a valid mimetype',
@@ -539,7 +666,59 @@ describe('storage.js', () => {
             assert.ok(nock.isDone());
         });
 
-        it('paramsSource object will take extension in name over mimetype', async () => {
+        it('paramsSource object will take extension in name over mimetype (as `type`)', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.jpeg',
+                type: 'image/jpeg',
+                name: 'file.png',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.jpeg')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/jpeg',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.png');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.png');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will take extension in name over mimetype (as `mimetype`)', async () => {
+            const paramsSource = {
+                url: 'https://example.com/photo/elephant.jpeg',
+                mimetype: 'image/jpeg',
+                name: 'file.png',
+                size: 11
+            };
+            const inDirectory = './in/fakeSource/filePath';
+
+            mockFs({ './in/fakeSource/filePath': {} });
+            assert.ok(fs.existsSync(inDirectory));
+
+            nock('https://example.com')
+                .get('/photo/elephant.jpeg')
+                .reply(200, 'hello world', {
+                    'content-type': 'image/jpeg',
+                    'content-length': 11
+                });
+
+            const source = await Storage.getSource(paramsSource, inDirectory);
+
+            assert.strictEqual(source.name, 'source.png');
+            assert.strictEqual(source.path, 'in/fakeSource/filePath/source.png');
+            assert.ok(nock.isDone());
+        });
+
+        it('paramsSource object will take extension in name over mimetype (as `mimeType` case sensitive)', async () => {
             const paramsSource = {
                 url: 'https://example.com/photo/elephant.jpeg',
                 mimeType: 'image/jpeg',


### PR DESCRIPTION
## Description

Unfortunately, we have 3 different ways we could store the source mimetype in the source. One of which was missing from the list: `source.mimetype`
This is actually where we store the mimetype in the source object in core so its our most common use case: https://git.corp.adobe.com/nui/core/blob/master/lib/update-source-metadata.js#L186
(ran into this when making unit tests in the sdk for block transfer)

Note: we should have a single source of truth for source mimetypes (the pipeline relies on `source.type` being defined, but the rest of the service is using either `mimeType` or `mimetype`

Fixes # none

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
