### PR TITLE
No hash for empty files

### DIFF
--- a/lib/rendition.js
+++ b/lib/rendition.js
@@ -125,7 +125,7 @@ class Rendition {
      */
     size() {
         // TODO: we should throw an error if this.path does not exist, aka no rendition produced
-        if (fs.existsSync(this.path)) {
+        if (this.path && fs.existsSync(this.path)) {
             return fs.statSync(this.path).size;
         }
     }

--- a/lib/rendition.js
+++ b/lib/rendition.js
@@ -124,8 +124,7 @@ class Rendition {
      * Gets the file size of the rendition (in bytes)
      */
     size() {
-        // TODO: Implement cache to avoid looking up file size every time
-        // TODO: we should throw an error if this.path does not exist, aka no rendition produce
+        // TODO: we should throw an error if this.path does not exist, aka no rendition produced
         if (fs.existsSync(this.path)) {
             return fs.statSync(this.path).size;
         }

--- a/lib/rendition.js
+++ b/lib/rendition.js
@@ -47,8 +47,12 @@ function fileHash(filename, algorithm) {
             const shasum = crypto.createHash(algorithm);
 
             const stream = fs.createReadStream(filename);
-            stream.on('data', data => shasum.update(data));
-            stream.on('end', () => resolve(shasum.digest('hex')));
+            stream.on('data', data => {
+                shasum.update(data);
+            });
+            stream.on('end', () => {
+                resolve(shasum.digest('hex'));
+            });
             stream.on('error', err => {
                 reject(`creating ${algorithm} hash failed: ${err.message || err}`);
             });
@@ -131,6 +135,10 @@ class Rendition {
     //  * Computes the SHA1 hash for the rendition
     //  */
     async sha1() {
+        if(this.size() === 0){
+            return null; // empty file, do not compute and cache hash just now
+        }
+
         if (!this._sha1) {
             this._sha1 = await fileHash(this.path, HASH_ALGORITHM);
         }

--- a/test/rendition.test.js
+++ b/test/rendition.test.js
@@ -95,6 +95,20 @@ describe("rendition.js", () => {
         assert.strictEqual(await rendition.sha1(), 'fe16bfbff4e31fcf726c18fe4051b71ee8c96150');
     });
 
+    it('verifies method sha1 does not compute a sha1 for an empty file', async function () {
+        const instructions = { "fmt": "png", "target": "TargetName" };
+        const directory = "/";
+        await fs.writeFile("/rendition1.png", '');
+
+        // an empty file should not get a hash
+        const rendition = new Rendition(instructions, directory, 1);
+        assert.strictEqual(await rendition.sha1(), null);
+
+        // write content into the file, now should get a hash
+        await fs.writeFile("/rendition1.png", PNG_CONTENTS);
+        assert.strictEqual(await rendition.sha1(), 'fe16bfbff4e31fcf726c18fe4051b71ee8c96150');
+    });
+
     it('verifies method sha1 handles not finding the file', async function () {
         const instructions = { "fmt": "png", "target": "TargetName" };
         const directory = "/";


### PR DESCRIPTION
## Description

There is a case in which a "wrong" hash for a rendition can be cached, namely when the hash is computed when the file exists on disk but has no content (yet). This means also all "empty" files would get the same hash (since the content "empty" is the same for all "empty" files). This PR ensures that the sha1 for an empty file is not computed (returns null instead of a sha1 hash), and hence not cached either.

Fixes [ASSETS-55](https://jira.corp.adobe.com/browse/ASSETS-55) maybe, at least it will reduce the scope.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
