### PR TITLE
ASSETS-20895 remove rendition data from action results

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -595,7 +595,6 @@ class Engine {
 
     getResult(output, err) {
         const result = {
-            rendition: output,
             requestId: this[INTERNAL].params.requestId,
         };
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -594,6 +594,7 @@ class Engine {
     }
 
     getResult(output, err) {
+        // make sure to not return urls, customer data or credentials
         const result = {
             requestId: this[INTERNAL].params.requestId,
         };


### PR DESCRIPTION
For https://jira.corp.adobe.com/browse/ASSETS-20895 Minimize activation response size of workers (COGS impact)
[related sdk pr](https://github.com/adobe/asset-compute-sdk/pull/202)

For workers using pipeline: Removed rendition and source data from activation results for pipeline actions.
Before code changes:
![image](https://user-images.githubusercontent.com/12173647/228024239-9edc8989-d992-4ce2-a09d-494642aeb7b5.png)


After code changes:
![image](https://user-images.githubusercontent.com/12173647/228024016-2c9737f0-8b0e-4030-829a-f7604aab7d84.png)

