### PR TITLE
ASSETS-12635: Add cgroupv2 compatibility

### DIFF
--- a/lib/storage/http.js
+++ b/lib/storage/http.js
@@ -21,6 +21,10 @@ const MAX_RETRY_DURATION_UPLOAD = 900000; // 15 mins
 const DEFAULT_MAX_CONCURRENT = 8;
 const DEFAULT_PREFERRED_PART_SIZE = 100 * 1024 * 1024; // Default part size is 100mb
 
+// cgroup file paths for v1 and v2
+const CONTAINER_MEMORY_SIZE_CGROUPV1 = '/sys/fs/cgroup/memory/memory.limit_in_bytes';
+const CONTAINER_MEMORY_SIZE_CGROUPV2 = '/sys/fs/cgroup/memory.max';
+
 /**
  * Get max concurrent value for node-httptransfer block transfer
  *  - This is to make sure there is enough memory available inside the container for httptransfer to handle the block transfer
@@ -31,13 +35,24 @@ const DEFAULT_PREFERRED_PART_SIZE = 100 * 1024 * 1024; // Default part size is 1
 async function getMaxConcurrent(preferredPartSize) {
     let containerMemorySize;
     try {
-        // get raw container memory size
-        const rawContainerMemory = await fs.readFile('/sys/fs/cgroup/memory/memory.limit_in_bytes');
+        // Try cgroupv2, fallback to cgroupv1
+        let rawContainerMemory;
+        try {
+            rawContainerMemory = await fs.readFile(CONTAINER_MEMORY_SIZE_CGROUPV2);
+            const trimmedMemory = rawContainerMemory.toString().trim();
+            // cgroupv2 can have the string 'max' - use default max concurrency
+            if (trimmedMemory === 'max') {
+                return DEFAULT_MAX_CONCURRENT;
+            }
+        } catch (error) {
+            console.log(`cgroupv2 failed with: ${error}, falling back to cgroupv1`);
+            rawContainerMemory = await fs.readFile(CONTAINER_MEMORY_SIZE_CGROUPV1);
+        }
         // parse container memory
         containerMemorySize = parseInt(rawContainerMemory, 10) || undefined;
     } catch (e) {
         // log error for reference but ignore
-        console.error(e);
+        console.error(`Error getting max concurrent value: ${e}`);
     }
     if (!Number.isFinite(containerMemorySize)) {
         // if undefined or not a valid finite number, return default max concurrency


### PR DESCRIPTION
## Description

Add support for reading memory limits from cgroupv2 file at /sys/fs/cgroup/memory.max, with automatic fallback to cgroupv1.

Partial fix for https://jira.corp.adobe.com/browse/ASSETS-12635
- Second fix will be in https://github.com/adobe/node-cgroup-metrics

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
